### PR TITLE
fix: #1 폴더 변경 취소 메시지 창 수정

### DIFF
--- a/oot/control/top_control.py
+++ b/oot/control/top_control.py
@@ -18,6 +18,9 @@ def __check_work_folder(work_dir):
     ext = ['png', 'jpg', 'gif']
     target_files = []
     [target_files.extend(glob.glob(work_dir + '/' + '*.' + e)) for e in ext]
+    if len(work_dir) == 0:
+        mb.showinfo("알림", "사용자가 선택을 취소했습니다")
+        return False
     if len(target_files) == 0:
         mb.showerror("에러", "해당 폴더에는 이미지 파일이 없습니다")
         return False


### PR DESCRIPTION
1451b94 fix: #1 폴더 변경 취소 메시지 창 수정

- 기존 폴더 변경 취소 시 showerror가 사용되고 "해당 폴더에는 이미지 파일이 없습니다"라는 문구가 출력되었습니다.
- clicked_change_folder() 내부의 __check_work_folder(work_dir)에서 len(work_dir)==0인 경우가 추가되었고, showinfo를 통해 "사용자가 선택을 취소했습니다"라는 메시지가 표시되도록 수정했습니다.

![image](https://github.com/user-attachments/assets/82b13104-ac36-4d95-ae2c-1a2c27385b6e)

- 기존의 showerror 기능도 정상적으로 작동함을 확인했습니다.

![image](https://github.com/user-attachments/assets/2ce76fa6-dff8-4dac-a596-07a0332d096f)
